### PR TITLE
Fix Python workbook reading

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### 6.1.2+62db5ab (Released 2024-4-9)
+* Additions:
+    * [[#62db5ab](https://github.com/CSBiology/FsSpreadsheet/commit/62db5abb62cfd411355f5e4b6a466aeb622e448e)] update project dependenices on FsSpreadsheet.Core
+
 ### 6.1.1+0f0535a (Released 2024-4-8)
 * Additions:
     * [[#0d578e2](https://github.com/CSBiology/FsSpreadsheet/commit/0d578e27d65179857267c0f4601bc75a22327b9a)] bump to 6.1.0

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+### 6.1.1+0f0535a (Released 2024-4-8)
+* Additions:
+    * [[#0d578e2](https://github.com/CSBiology/FsSpreadsheet/commit/0d578e27d65179857267c0f4601bc75a22327b9a)] bump to 6.1.0
+* Bugfixes:
+    * [[#0f0535a](https://github.com/CSBiology/FsSpreadsheet/commit/0f0535a4afbc44e5980c89e608334b96e38a4a7d)] check and fix py xlsx reader rescanning rows
+
 ### 6.1.0+ed6795c (Released 2024-3-19)
 * Additions:
     * [[#3f1fb55](https://github.com/CSBiology/FsSpreadsheet/commit/3f1fb55e75d2ea56dec8787f0e6dfceccfd19ef5)] start working on json writing

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fslab/fsspreadsheet",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "description": "Minimal spreadsheet creation and manipulation using exceljs io.",
   "type": "module",
   "main": "Xlsx.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fslab/fsspreadsheet",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Minimal spreadsheet creation and manipulation using exceljs io.",
   "type": "module",
   "main": "Xlsx.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fsspreadsheet"
-version = "6.1.0"
+version = "6.1.1"
 description = "Fable library for Spreadsheet creation and manipulation"
 authors = ["Heinrich Lukas Weil <hlweil@outlook.de>", "Kevin Frey <freymaurer@gmx.de>"]
 maintainers = ["Oliver Maus"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fsspreadsheet"
-version = "6.1.1"
+version = "6.1.2"
 description = "Fable library for Spreadsheet creation and manipulation"
 authors = ["Heinrich Lukas Weil <hlweil@outlook.de>", "Kevin Frey <freymaurer@gmx.de>"]
 maintainers = ["Oliver Maus"]

--- a/src/FsSpreadsheet.CsvIO/FsSpreadsheet.CsvIO.fsproj
+++ b/src/FsSpreadsheet.CsvIO/FsSpreadsheet.CsvIO.fsproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\FsSpreadsheet\FsSpreadsheet.fsproj" PackageVersion="[5.0.0, 6.0.0)" />
+    <ProjectReference Include="..\FsSpreadsheet\FsSpreadsheet.fsproj" PackageVersion="[6.0.0, 7.0.0)" />
   </ItemGroup>
 
   <Target Name="UseExplicitPackageVersions" BeforeTargets="GenerateNuspec">

--- a/src/FsSpreadsheet.Interactive/FsSpreadsheet.Interactive.fsproj
+++ b/src/FsSpreadsheet.Interactive/FsSpreadsheet.Interactive.fsproj
@@ -41,7 +41,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <ProjectReference Include="..\FsSpreadsheet\FsSpreadsheet.fsproj" PackageVersion="[5.0.0, 6.0.0)" />
+    <ProjectReference Include="..\FsSpreadsheet\FsSpreadsheet.fsproj" PackageVersion="[6.0.0, 7.0.0)" />
     <PackageReference Include="Giraffe.ViewEngine" Version="1.4.0" />
     <PackageReference Include="Microsoft.DotNet.Interactive" Version="1.0.0-beta.23165.2" />
     <PackageReference Include="Microsoft.DotNet.Interactive.Formatting" Version="1.0.0-beta.23165.2" />

--- a/src/FsSpreadsheet.Net/FsSpreadsheet.Net.fsproj
+++ b/src/FsSpreadsheet.Net/FsSpreadsheet.Net.fsproj
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\FsSpreadsheet\FsSpreadsheet.fsproj" PackageVersion="[5.0.0, 6.0.0)" />
+    <ProjectReference Include="..\FsSpreadsheet\FsSpreadsheet.fsproj" PackageVersion="[6.0.0, 7.0.0)" />
   </ItemGroup>
 
   <Target Name="UseExplicitPackageVersions" BeforeTargets="GenerateNuspec">

--- a/src/FsSpreadsheet.Py/Workbook.fs
+++ b/src/FsSpreadsheet.Py/Workbook.fs
@@ -25,6 +25,7 @@ module PyWorkbook =
         pyWB.worksheets |> Array.iter (fun (ws : Worksheet) -> 
             if ws.title <> "Sheet" && ws.values.Length <> 0 then
                 let w = PyWorksheet.toFsWorksheet ws
+                w.RescanRows()
                 fsWB.AddWorksheet(w) |> ignore
         )
         fsWB

--- a/tests/FsSpreadsheet.Py.Tests/DefaultIO.Tests.fs
+++ b/tests/FsSpreadsheet.Py.Tests/DefaultIO.Tests.fs
@@ -11,6 +11,10 @@ let private readFromTestFile (testFile: DefaultTestObject.TestFiles) =
 
 let private tests_Read = testList "Read" [
 
+    testCase "ExcelRowCount" <| fun _ ->
+        let wb = readFromTestFile DefaultTestObject.TestFiles.Excel
+        Expect.isTrue (wb.GetWorksheetAt(1).Rows.Count > 0) "ExcelRowCount"
+
     testCase "Excel" <| fun _ ->
         let wb = readFromTestFile DefaultTestObject.TestFiles.Excel
         Expect.isDefaultTestObject wb


### PR DESCRIPTION
Conversion from PyWorkbook to FsWorkbook did not call "RescanRows". This caused problems when parsing and then calling "GetRows"