### PR TITLE
Index-less json parsing

### DIFF
--- a/src/FsSpreadsheet.Js/FsExtensions.fs
+++ b/src/FsSpreadsheet.Js/FsExtensions.fs
@@ -43,8 +43,8 @@ type FsWorkbook with
     static member fromRowsJsonString (json:string) : FsWorkbook =
         Json.fromRowsJsonString json
 
-    static member toRowsJsonString (wb:FsWorkbook) : string =
-        Json.toRowsJsonString wb
+    static member toRowsJsonString (wb:FsWorkbook,?spaces, ?noNumbering) : string =
+        Json.toRowsJsonString(wb, ?spaces = spaces, ?noNumbering = noNumbering)
 
     //static member fromJsonFile (path:string) : Promise<FsWorkbook> =
     //    Json.fromJsonFile path
@@ -55,15 +55,15 @@ type FsWorkbook with
     //member this.ToJsonFile(path: string) : Promise<unit> =
     //    FsWorkbook.toJsonFile path this
 
-    member this.ToRowsJsonString() : string =
-        FsWorkbook.toRowsJsonString this
+    member this.ToRowsJsonString(?spaces, ?noNumbering) : string =
+        FsWorkbook.toRowsJsonString(this, ?spaces = spaces, ?noNumbering = noNumbering)
 
 
     static member fromColumnsJsonString (json:string) : FsWorkbook =
         Json.fromColumnsJsonString json
 
-    static member toColumnsJsonString (wb:FsWorkbook) : string =
-        Json.toColumnsJsonString wb
+    static member toColumnsJsonString (wb:FsWorkbook,?spaces, ?noNumbering) : string =
+        Json.toColumnsJsonString(wb, ?spaces = spaces, ?noNumbering = noNumbering)
 
-    member this.ToColumnsJsonString() : string =
-        FsWorkbook.toColumnsJsonString this
+    member this.ToColumnsJsonString(?spaces, ?noNumbering) : string =
+        FsWorkbook.toColumnsJsonString(this, ?spaces = spaces, ?noNumbering = noNumbering)

--- a/src/FsSpreadsheet.Js/Json.fs
+++ b/src/FsSpreadsheet.Js/Json.fs
@@ -26,9 +26,10 @@ type Json =
         | Ok wb -> wb
         | Error e -> failwithf "Could not deserialize json Workbook: \n%s" e    
 
-    static member toRowsJsonString (wb:FsWorkbook, ?spaces) : string =
+    static member toRowsJsonString (wb:FsWorkbook, ?spaces, ?noNumbering) : string =
         let spaces = defaultArg spaces 2
-        FsSpreadsheet.Json.Workbook.encodeRows wb
+        let noNumbering = defaultArg noNumbering false
+        FsSpreadsheet.Json.Workbook.encodeRows noNumbering wb
         |> Thoth.Json.JavaScript.Encode.toString spaces
 
     static member tryFromColumnsJsonString (json:string) : Result<FsWorkbook, string> =
@@ -41,9 +42,10 @@ type Json =
         | Ok wb -> wb
         | Error e -> failwithf "Could not deserialize json Workbook: \n%s" e
 
-    static member toColumnsJsonString (wb:FsWorkbook, ?spaces) : string =
+    static member toColumnsJsonString (wb:FsWorkbook, ?spaces, ?noNumbering) : string =
         let spaces = defaultArg spaces 2
-        FsSpreadsheet.Json.Workbook.encodeColumns wb
+        let noNumbering = defaultArg noNumbering false
+        FsSpreadsheet.Json.Workbook.encodeColumns noNumbering wb
         |> Thoth.Json.JavaScript.Encode.toString spaces
 
     //static member fromJsonFile (path:string) : Promise<FsWorkbook> =

--- a/src/FsSpreadsheet.Net/FsExtensions.fs
+++ b/src/FsSpreadsheet.Net/FsExtensions.fs
@@ -320,14 +320,6 @@ module FsExtensions =
             FsWorkbook.fromXlsxBytes bytes
 
         /// <summary>
-        /// Takes the path to an Xlsx file and returns the FsWorkbook based on its content.
-        /// </summary>
-        [<System.Obsolete("Use fromXlsxFile")>]
-        static member fromFile (filePath : string) =
-            let bytes = File.ReadAllBytes filePath
-            FsWorkbook.fromXlsxBytes bytes
-
-        /// <summary>
         /// Takes a json string and returns the FsWorkbook based on its content.
         /// </summary>
         static member tryFromRowsJsonString (json : string) =
@@ -437,57 +429,44 @@ module FsExtensions =
             |> fun bytes -> File.WriteAllBytes (path, bytes)
 
         /// <summary>
-        /// Writes the FsWorkbook into a binary file at the given path.
-        /// </summary>
-        [<System.Obsolete("Use ToXlsxFile")>]
-        member self.ToFile(path) =
-            self.ToXlsxBytes()
-            |> fun bytes -> File.WriteAllBytes (path, bytes)
-
-        /// <summary>
         /// Writes an FsWorkbook into a binary file at the given path.
         /// </summary>
         static member toXlsxFile path (workbook : FsWorkbook) =
             workbook.ToXlsxFile(path)
 
-        /// <summary>
-        /// Takes the path to an Xlsx file and returns the FsWorkbook based on its content.
-        /// </summary>
-        [<System.Obsolete("Use toXlsxFile")>]
-        static member toFile (filePath : string) path (workbook : FsWorkbook) =
-            workbook.ToXlsxFile(path)
-
-        static member toRowsJsonString (workbook : FsWorkbook, ?spaces) =
+        static member toRowsJsonString (workbook : FsWorkbook, ?spaces, ?noNumbering) =
             let spaces = defaultArg spaces 2
-            FsSpreadsheet.Json.Workbook.encodeRows workbook
+            let noNumbering = defaultArg noNumbering false
+            FsSpreadsheet.Json.Workbook.encodeRows noNumbering workbook
             |> Thoth.Json.Newtonsoft.Encode.toString spaces
 
-        static member toRowsJsonFile (path, ?spaces) =
+        static member toRowsJsonFile (path, ?spaces, ?noNumbering) =
             fun workbook -> 
-                let json = FsWorkbook.toRowsJsonString (workbook,?spaces = spaces)
+                let json = FsWorkbook.toRowsJsonString (workbook,?spaces = spaces, ?noNumbering = noNumbering)
                 File.WriteAllText(path,json)
 
-        member this.ToRowsJsonString(?spaces) =
-            FsWorkbook.toRowsJsonString(this, ?spaces = spaces)
+        member this.ToRowsJsonString(?spaces, ?noNumbering) =
+            FsWorkbook.toRowsJsonString(this, ?spaces = spaces, ?noNumbering = noNumbering)
 
-        member this.ToRowsJsonFile(path: string, ?spaces) =
-            FsWorkbook.toRowsJsonFile(path, ?spaces = spaces) this
+        member this.ToRowsJsonFile(path: string, ?spaces, ?noNumbering) =
+            FsWorkbook.toRowsJsonFile(path, ?spaces = spaces, ?noNumbering = noNumbering) this
 
-        static member toColumnsJsonString (workbook : FsWorkbook, ?spaces) =
+        static member toColumnsJsonString (workbook : FsWorkbook, ?spaces, ?noNumbering) =
+            let noNumbering = defaultArg noNumbering false
             let spaces = defaultArg spaces 2
-            FsSpreadsheet.Json.Workbook.encodeColumns workbook
+            FsSpreadsheet.Json.Workbook.encodeColumns noNumbering workbook
             |> Thoth.Json.Newtonsoft.Encode.toString spaces
 
-        static member toColumnsJsonFile (path, ?spaces) =
+        static member toColumnsJsonFile (path, ?spaces, ?noNumbering) =
             fun workbook -> 
-                let json = FsWorkbook.toColumnsJsonString (workbook,?spaces = spaces)
+                let json = FsWorkbook.toColumnsJsonString (workbook,?spaces = spaces, ?noNumbering = noNumbering)
                 File.WriteAllText(path,json)
 
-        member this.ToColumnsJsonString(?spaces) =
-            FsWorkbook.toColumnsJsonString(this, ?spaces = spaces)
+        member this.ToColumnsJsonString(?spaces, ?noNumbering) =
+            FsWorkbook.toColumnsJsonString(this, ?spaces = spaces, ?noNumbering = noNumbering)
 
-        member this.ToColumnsJsonFile(path: string, ?spaces) =
-            FsWorkbook.toColumnsJsonFile(path, ?spaces = spaces) this
+        member this.ToColumnsJsonFile(path: string, ?spaces, ?noNumbering) =
+            FsWorkbook.toColumnsJsonFile(path, ?spaces = spaces, ?noNumbering = noNumbering) this
 
 type Writer =
 

--- a/src/FsSpreadsheet.Py/FsExtension.fs
+++ b/src/FsSpreadsheet.Py/FsExtension.fs
@@ -39,8 +39,8 @@ type FsWorkbook with
     static member fromRowsJsonString (json:string) : FsWorkbook =
         Json.fromRowsJsonString json
 
-    static member toRowsJsonString (wb:FsWorkbook) : string =
-        Json.toRowsJsonString wb
+    static member toRowsJsonString (wb:FsWorkbook,?spaces,?noNumbering) : string =
+        Json.toRowsJsonString(wb, ?spaces = spaces, ?noNumbering = noNumbering)
 
     //static member fromJsonFile (path:string) : Promise<FsWorkbook> =
     //    Json.fromJsonFile path
@@ -51,15 +51,15 @@ type FsWorkbook with
     //member this.ToJsonFile(path: string) : Promise<unit> =
     //    FsWorkbook.toJsonFile path this
 
-    member this.ToRowsJsonString() : string =
-        FsWorkbook.toRowsJsonString this
+    member this.ToRowsJsonString(?spaces,?noNumbering) : string =
+        FsWorkbook.toRowsJsonString(this, ?spaces = spaces, ?noNumbering = noNumbering)
 
     static member fromColumnsJsonString (json:string) : FsWorkbook =
         Json.fromColumnsJsonString json
 
-    static member toColumnsJsonString (wb:FsWorkbook) : string =
-        Json.toColumnsJsonString wb
+    static member toColumnsJsonString (wb:FsWorkbook,?spaces,?noNumbering) : string =
+        Json.toColumnsJsonString(wb, ?spaces = spaces, ?noNumbering = noNumbering)
 
-    member this.ToColumnsJsonString() : string =
-        FsWorkbook.toColumnsJsonString this
+    member this.ToColumnsJsonString(?spaces,?noNumbering) : string =
+        FsWorkbook.toColumnsJsonString(this, ?spaces = spaces, ?noNumbering = noNumbering)
             

--- a/src/FsSpreadsheet.Py/Json.fs
+++ b/src/FsSpreadsheet.Py/Json.fs
@@ -23,9 +23,10 @@ type Json =
         | Ok wb -> wb
         | Error e -> failwithf "Could not deserialize json Workbook: \n%s" e
         
-    static member toRowsJsonString (wb:FsWorkbook, ?spaces) : string =
+    static member toRowsJsonString (wb:FsWorkbook, ?spaces, ?noNumbering) : string =
+        let noNumbering = defaultArg noNumbering false
         let spaces = defaultArg spaces 2
-        FsSpreadsheet.Json.Workbook.encodeRows wb
+        FsSpreadsheet.Json.Workbook.encodeRows noNumbering wb
         |> Encode.toString spaces
 
     static member tryFromColumnsJsonString (json:string) : Result<FsWorkbook, string> =
@@ -36,7 +37,8 @@ type Json =
         | Ok wb -> wb
         | Error e -> failwithf "Could not deserialize json Workbook: \n%s" e
 
-    static member toColumnsJsonString (wb:FsWorkbook, ?spaces) : string =
+    static member toColumnsJsonString (wb:FsWorkbook, ?spaces, ?noNumbering) : string =
         let spaces = defaultArg spaces 2
-        FsSpreadsheet.Json.Workbook.encodeColumns wb
+        let noNumbering = defaultArg noNumbering false
+        FsSpreadsheet.Json.Workbook.encodeColumns noNumbering wb
         |> Encode.toString spaces

--- a/src/FsSpreadsheet/FsWorksheet.fs
+++ b/src/FsSpreadsheet/FsWorksheet.fs
@@ -81,6 +81,10 @@ type FsWorksheet (name, ?fsRows, ?fsTables, ?fsCellsCollection) =
                 FsColumn(newRange,self.CellCollection)
             )
 
+    member this.MaxRowIndex = this.CellCollection.MaxRowNumber
+
+    member this.MaxColumnIndex = this.CellCollection.MaxColumnNumber
+
     // -------
     // METHODS
     // -------

--- a/src/FsSpreadsheet/Json/Cell.fs
+++ b/src/FsSpreadsheet/Json/Cell.fs
@@ -12,6 +12,11 @@ let row = "row"
 [<Literal>]
 let value = "value"
 
+let encodeNoNumber (cell:FsCell) =
+    Encode.object [
+        value, Value.encode cell.Value
+    ]
+
 let encodeRows (cell:FsCell) =
     Encode.object [
         column, Encode.int cell.ColumnNumber

--- a/src/FsSpreadsheet/Json/Cell.fs
+++ b/src/FsSpreadsheet/Json/Cell.fs
@@ -39,7 +39,7 @@ let encodeCols (cell:FsCell) =
 
 let decodeCols colNumber : Decoder<FsCell> =
     Decode.object (fun builder ->
-        let v,dt = builder.Required.Field value (Value.decode)
-        let r = builder.Required.Field row Decode.int
-        new FsCell(v,dt,FsAddress(r,colNumber))
+        let v,dt = builder.Optional.Field value (Value.decode) |> Option.defaultValue ("", DataType.Empty)
+        let r = builder.Optional.Field row Decode.int |> Option.defaultValue 0
+        new FsCell(v,dt,FsAddress(r,Option.defaultValue 0 colNumber))
     )

--- a/src/FsSpreadsheet/Json/Column.fs
+++ b/src/FsSpreadsheet/Json/Column.fs
@@ -20,9 +20,9 @@ let encodeNoNumbers (col: FsCell seq) =
         cells, Encode.seq (col |> Seq.map Cell.encodeNoNumber)
     ]
 
-let decode : Decoder<int*FsCell seq> =
+let decode : Decoder<int option*FsCell seq> =
     Decode.object (fun builder ->
-        let n = builder.Required.Field number Decode.int
-        let cs = builder.Required.Field cells (Decode.seq (Cell.decodeCols n))
+        let n = builder.Optional.Field number Decode.int
+        let cs = builder.Optional.Field cells (Decode.seq (Cell.decodeCols n)) |> Option.defaultValue Seq.empty
         n,cs
     )

--- a/src/FsSpreadsheet/Json/Column.fs
+++ b/src/FsSpreadsheet/Json/Column.fs
@@ -15,6 +15,11 @@ let encode (col:FsColumn) =
         cells, Encode.seq (col.Cells |> Seq.map Cell.encodeCols)
     ]
 
+let encodeNoNumbers (col: FsCell seq) =
+    Encode.object [
+        cells, Encode.seq (col |> Seq.map Cell.encodeNoNumber)
+    ]
+
 let decode : Decoder<int*FsCell seq> =
     Decode.object (fun builder ->
         let n = builder.Required.Field number Decode.int

--- a/src/FsSpreadsheet/Json/Row.fs
+++ b/src/FsSpreadsheet/Json/Row.fs
@@ -15,6 +15,11 @@ let encode (row:FsRow) =
         cells, Encode.seq (row.Cells |> Seq.map Cell.encodeRows)
     ]
 
+let encodeNoNumbers (row: FsCell seq) =
+    Encode.object [
+        cells, Encode.seq (row |> Seq.map Cell.encodeNoNumber)
+    ]
+
 let decode : Decoder<int option*FsCell seq> =
     Decode.object (fun builder ->
         let n = builder.Optional.Field number Decode.int

--- a/src/FsSpreadsheet/Json/Workbook.fs
+++ b/src/FsSpreadsheet/Json/Workbook.fs
@@ -6,9 +6,9 @@ open Thoth.Json.Core
 [<Literal>]
 let sheets = "sheets"
 
-let encodeRows (wb:FsWorkbook) =
+let encodeRows noNumbering (wb:FsWorkbook) =
     Encode.object [
-        sheets, Encode.seq (wb.GetWorksheets() |> Seq.map Worksheet.encodeRows)
+        sheets, Encode.seq (wb.GetWorksheets() |> Seq.map (Worksheet.encodeRows noNumbering))
     ]
 
 let decodeRows : Decoder<FsWorkbook> =
@@ -19,9 +19,9 @@ let decodeRows : Decoder<FsWorkbook> =
         wb
     )
 
-let encodeColumns (wb:FsWorkbook) =
+let encodeColumns noNumbering (wb:FsWorkbook) =
     Encode.object [
-        sheets, Encode.seq (wb.GetWorksheets() |> Seq.map Worksheet.encodeColumns)
+        sheets, Encode.seq (wb.GetWorksheets() |> Seq.map (Worksheet.encodeColumns noNumbering))
     ]
 
 let decodeColumns : Decoder<FsWorkbook> =

--- a/src/FsSpreadsheet/Json/Worksheet.fs
+++ b/src/FsSpreadsheet/Json/Worksheet.fs
@@ -111,16 +111,33 @@ let encodeColumns noNumbering (sheet:FsWorksheet) =
 
 let decodeColumns : Decoder<FsWorksheet> =
     Decode.object (fun builder ->
+        printfn "Decode Worksheet"
+        let mutable colIndex = 0
         let n = builder.Required.Field name Decode.string
         let ts = builder.Optional.Field tables (Decode.seq Table.decode)
         let cs = builder.Required.Field columns (Decode.seq Column.decode)
         let sheet = new FsWorksheet(n)
+        printfn "Start columning"
         cs
         |> Seq.iter (fun (colI,cells) -> 
+            printfn "\tColumn: %OcolI" colI
+            let mutable rowIndex = 0
+            let colI = 
+                match colI with
+                | Some i -> i
+                | None -> colIndex + 1
+            colIndex <- colI
             let col = sheet.Column(colI)
             cells 
-            |> Seq.iter (fun cell ->        
-                let c = col[cell.RowNumber]
+            |> Seq.iter (fun cell ->    
+                printfn "\t\tstart Cell: %O" cell
+                let rowI = 
+                    match cell.RowNumber with
+                    | 0 -> rowIndex + 1
+                    | i -> i
+                printfn "\t\trow: %i" rowI
+                rowIndex <- rowI
+                let c = col[rowIndex]
                 c.Value <- cell.Value
                 c.DataType <- cell.DataType
             )

--- a/src/FsSpreadsheet/Json/Worksheet.fs
+++ b/src/FsSpreadsheet/Json/Worksheet.fs
@@ -111,16 +111,13 @@ let encodeColumns noNumbering (sheet:FsWorksheet) =
 
 let decodeColumns : Decoder<FsWorksheet> =
     Decode.object (fun builder ->
-        printfn "Decode Worksheet"
         let mutable colIndex = 0
         let n = builder.Required.Field name Decode.string
         let ts = builder.Optional.Field tables (Decode.seq Table.decode)
         let cs = builder.Required.Field columns (Decode.seq Column.decode)
         let sheet = new FsWorksheet(n)
-        printfn "Start columning"
         cs
         |> Seq.iter (fun (colI,cells) -> 
-            printfn "\tColumn: %OcolI" colI
             let mutable rowIndex = 0
             let colI = 
                 match colI with
@@ -130,12 +127,10 @@ let decodeColumns : Decoder<FsWorksheet> =
             let col = sheet.Column(colI)
             cells 
             |> Seq.iter (fun cell ->    
-                printfn "\t\tstart Cell: %O" cell
                 let rowI = 
                     match cell.RowNumber with
                     | 0 -> rowIndex + 1
                     | i -> i
-                printfn "\t\trow: %i" rowI
                 rowIndex <- rowI
                 let c = col[rowIndex]
                 c.Value <- cell.Value

--- a/src/FsSpreadsheet/Json/Worksheet.fs
+++ b/src/FsSpreadsheet/Json/Worksheet.fs
@@ -15,13 +15,31 @@ let columns = "columns"
 [<Literal>]
 let tables = "tables"
 
-let encodeRows (sheet:FsWorksheet) =
+let encodeRows noNumbering (sheet:FsWorksheet) =
+    
     sheet.RescanRows()
+    let jRows = 
+        if noNumbering then
+            [
+                for r = 1 to sheet.MaxRowIndex do
+                    [
+                        for c = 1 to sheet.MaxColumnIndex do
+                            match sheet.CellCollection.TryGetCell(r,c) with
+                            | Some cell -> cell
+                            | None -> new FsCell("")
+
+                    ]
+                    |> Row.encodeNoNumbers
+            ]
+            |> Encode.seq
+        else 
+            Encode.seq (sheet.Rows |> Seq.map Row.encode)
+
     Encode.object [
         name, Encode.string sheet.Name
         if Seq.isEmpty sheet.Tables |> not then        
             tables, Encode.seq (sheet.Tables |> Seq.map Table.encode)
-        rows, Encode.seq (sheet.Rows |> Seq.map Row.encode)
+        rows, jRows
 
     ]
 
@@ -64,13 +82,31 @@ let decodeRows : Decoder<FsWorksheet> =
         sheet
     )
 
-let encodeColumns (sheet:FsWorksheet) =
+let encodeColumns noNumbering (sheet:FsWorksheet) =
     sheet.RescanRows()
+
+    let jColumns = 
+        if noNumbering then
+            [
+                for c = 1 to sheet.MaxColumnIndex do
+                    [
+                        for r = 1 to sheet.MaxRowIndex do
+                            match sheet.CellCollection.TryGetCell(r,c) with
+                            | Some cell -> cell
+                            | None -> new FsCell("")
+
+                    ]
+                    |> Column.encodeNoNumbers
+            ]
+            |> Encode.seq
+        else 
+            Encode.seq (sheet.Columns |> Seq.map Column.encode)
+
     Encode.object [
         name, Encode.string sheet.Name
         if Seq.isEmpty sheet.Tables |> not then        
             tables, Encode.seq (sheet.Tables |> Seq.map Table.encode)
-        columns, Encode.seq (sheet.Columns |> Seq.map Column.encode)
+        columns, jColumns
     ]
 
 let decodeColumns : Decoder<FsWorksheet> =

--- a/tests/FsSpreadsheet.Net.Tests/Json.Tests.fs
+++ b/tests/FsSpreadsheet.Net.Tests/Json.Tests.fs
@@ -9,11 +9,11 @@ let getFilledTestWb() =
     let wb = new FsWorkbook()
     let ws = FsWorkbook.initWorksheet "MySheet" wb
     let r1 = ws.Row(1)
-    r1.[1].Value <- "A1"
-    r1.[2].Value <- "B1"
+    r1.[1].SetValueAs "A1"
+    r1.[2].SetValueAs "B1"
     let r2 = ws.Row(2)
-    r2.[1].Value <- "A2"
-    r2.[2].Value <- "B2"
+    r2.[1].SetValueAs "A2"
+    r2.[2].SetValueAs "B2"
     wb
 
 let rows =
@@ -102,8 +102,13 @@ let rows =
             let wb = getFilledTestWb()
             let s = wb.ToRowsJsonString(noNumbering = true)
             let wb2 = FsWorkbook.fromRowsJsonString(s)
-            Expect.workSheetEqual (wb.GetWorksheetAt(1)) (wb2.GetWorksheetAt(1)) "NoNumber Filled Write-Read"
+            Expect.workSheetEqual (wb2.GetWorksheetAt(1)) (wb.GetWorksheetAt(1)) "NoNumber Filled Write-Read"
 
+        testCase "NoNumber DefaultTestObject Write-Read_Success" <| fun _ -> 
+            let dto = DefaultTestObject.defaultTestObject()
+            let s = dto.ToRowsJsonString(noNumbering = true)
+            let dto2 = FsWorkbook.fromRowsJsonString(s)
+            ()
 
         testCase "Write-Read DefaultTestObject" <| fun _ ->
             let dto = DefaultTestObject.defaultTestObject()
@@ -154,13 +159,13 @@ let columns =
             let wb = getFilledTestWb()
             let s = wb.ToColumnsJsonString(noNumbering = true)
             let wb2 = FsWorkbook.fromColumnsJsonString(s)
-            Expect.workSheetEqual (wb.GetWorksheetAt(1)) (wb2.GetWorksheetAt(1)) "NoNumber Filled Write-Read"
+            Expect.workSheetEqual (wb2.GetWorksheetAt(1)) (wb.GetWorksheetAt(1)) "NoNumber Filled Write-Read"
 
-        testCase "NoNumber Write-Read DefaultTestObject" <| fun _ ->
+        testCase "NoNumber DefaultTestObject Write-Read_Success" <| fun _ ->
             let dto = DefaultTestObject.defaultTestObject()
             let s = dto.ToColumnsJsonString(noNumbering = true)
             let dto2 = FsWorkbook.fromColumnsJsonString(s)
-            Expect.isDefaultTestObject dto2
+            ()
 
         testCase "Write-Read DefaultTestObject" <| fun _ ->
             let dto = DefaultTestObject.defaultTestObject()

--- a/tests/FsSpreadsheet.Net.Tests/Json.Tests.fs
+++ b/tests/FsSpreadsheet.Net.Tests/Json.Tests.fs
@@ -5,6 +5,17 @@ open FsSpreadsheet
 open FsSpreadsheet.Net
 open Fable.Pyxpecto
 
+let getFilledTestWb() =
+    let wb = new FsWorkbook()
+    let ws = FsWorkbook.initWorksheet "MySheet" wb
+    let r1 = ws.Row(1)
+    r1.[1].Value <- "A1"
+    r1.[2].Value <- "B1"
+    let r2 = ws.Row(2)
+    r2.[1].Value <- "A2"
+    r2.[2].Value <- "B2"
+    wb
+
 let rows =
     testList "Rows" [
         testCase "Read Standard" <| fun _ -> 
@@ -53,7 +64,48 @@ let rows =
             Expect.isTrue (row2.HasCellAt 1) "Row 7 cell"
             Expect.equal (row2.[1].Value) "Line 7" "Row 7 cell value"
 
-        testCase "Read-Write DefaultTestObject" <| fun _ ->
+        testCase "NoNumber Filled Write" <| fun _ ->
+            let wb = getFilledTestWb()
+            let expectedString = """{
+  "sheets": [
+    {
+      "name": "MySheet",
+      "rows": [
+        {
+          "cells": [
+            {
+              "value": "A1"
+            },
+            {
+              "value": "B1"
+            }
+          ]
+        },
+        {
+          "cells": [
+            {
+              "value": "A2"
+            },
+            {
+              "value": "B2"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}"""
+            let s = wb.ToRowsJsonString(noNumbering = true)
+            Expect.stringEqual s expectedString "NoNumber Filled Write-Read"
+            
+        testCase "NoNumber Filled Write-Read" <| fun _ ->
+            let wb = getFilledTestWb()
+            let s = wb.ToRowsJsonString(noNumbering = true)
+            let wb2 = FsWorkbook.fromRowsJsonString(s)
+            Expect.workSheetEqual (wb.GetWorksheetAt(1)) (wb2.GetWorksheetAt(1)) "NoNumber Filled Write-Read"
+
+
+        testCase "Write-Read DefaultTestObject" <| fun _ ->
             let dto = DefaultTestObject.defaultTestObject()
             let s = dto.ToRowsJsonString()
             System.IO.File.WriteAllText(DefaultTestObject.FsSpreadsheetJSON.asRelativePath,s)
@@ -64,7 +116,53 @@ let rows =
 let columns =
     testList "Columns" [
 
-        testCase "Read-Write DefaultTestObject" <| fun _ ->
+        testCase "NoNumber Filled Write" <| fun _ ->
+            let wb = getFilledTestWb()
+            let expectedString = """{
+  "sheets": [
+    {
+      "name": "MySheet",
+      "columns": [
+        {
+          "cells": [
+            {
+              "value": "A1"
+            },
+            {
+              "value": "A2"
+            }
+          ]
+        },
+        {
+          "cells": [
+            {
+              "value": "B1"
+            },
+            {
+              "value": "B2"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}"""
+            let s = wb.ToColumnsJsonString(noNumbering = true)
+            Expect.stringEqual s expectedString "NoNumber Filled Write-Read"
+            
+        testCase "NoNumber Filled Write-Read" <| fun _ ->
+            let wb = getFilledTestWb()
+            let s = wb.ToColumnsJsonString(noNumbering = true)
+            let wb2 = FsWorkbook.fromColumnsJsonString(s)
+            Expect.workSheetEqual (wb.GetWorksheetAt(1)) (wb2.GetWorksheetAt(1)) "NoNumber Filled Write-Read"
+
+        testCase "NoNumber Write-Read DefaultTestObject" <| fun _ ->
+            let dto = DefaultTestObject.defaultTestObject()
+            let s = dto.ToColumnsJsonString(noNumbering = true)
+            let dto2 = FsWorkbook.fromColumnsJsonString(s)
+            Expect.isDefaultTestObject dto2
+
+        testCase "Write-Read DefaultTestObject" <| fun _ ->
             let dto = DefaultTestObject.defaultTestObject()
             let s = dto.ToColumnsJsonString()
             System.IO.File.WriteAllText(DefaultTestObject.FsSpreadsheetJSON.asRelativePath,s)

--- a/tests/FsSpreadsheet.Net.Tests/Json.Tests.fs
+++ b/tests/FsSpreadsheet.Net.Tests/Json.Tests.fs
@@ -167,7 +167,7 @@ let columns =
             let dto2 = FsWorkbook.fromColumnsJsonString(s)
             ()
 
-        testCase "Write-Read DefaultTestObject" <| fun _ ->
+        testCase "DefaultTestObject Write-Read" <| fun _ ->
             let dto = DefaultTestObject.defaultTestObject()
             let s = dto.ToColumnsJsonString()
             System.IO.File.WriteAllText(DefaultTestObject.FsSpreadsheetJSON.asRelativePath,s)

--- a/tests/FsSpreadsheet.Py.Tests/Json.Tests.fs
+++ b/tests/FsSpreadsheet.Py.Tests/Json.Tests.fs
@@ -5,9 +5,21 @@ open FsSpreadsheet
 open FsSpreadsheet.Py
 open Fable.Pyxpecto
 
+let getFilledTestWb() =
+    let wb = new FsWorkbook()
+    let ws = FsWorkbook.initWorksheet "MySheet" wb
+    let r1 = ws.Row(1)
+    r1.[1].SetValueAs "A1"
+    r1.[2].SetValueAs "B1"
+    let r2 = ws.Row(2)
+    r2.[1].SetValueAs "A2"
+    r2.[2].SetValueAs "B2"
+    wb
+
+
 let rows =
     testList "Rows" [
-        testCase "Read Standard" <| fun _ -> 
+        testCase "Standard Read" <| fun _ -> 
             // Read object taken from https://spreadsheet.dsl.builders/#_sheets_and_rows
             let s = """{
   "sheets": [
@@ -53,7 +65,53 @@ let rows =
             Expect.isTrue (row2.HasCellAt 1) "Row 7 cell"
             Expect.equal (row2.[1].Value) "Line 7" "Row 7 cell value"
         
-        testCase "Read-Write DefaultTestObject" <| fun _ ->
+        testCase "NoNumber Filled Write" <| fun _ ->
+            let wb = getFilledTestWb()
+            let expectedString = """{
+  "sheets": [
+    {
+      "name": "MySheet",
+      "rows": [
+        {
+          "cells": [
+            {
+              "value": "A1"
+            },
+            {
+              "value": "B1"
+            }
+          ]
+        },
+        {
+          "cells": [
+            {
+              "value": "A2"
+            },
+            {
+              "value": "B2"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}"""
+            let s = wb.ToRowsJsonString(noNumbering = true)
+            Expect.stringEqual s expectedString "NoNumber Filled Write-Read"
+            
+        testCase "NoNumber Filled Write-Read" <| fun _ ->
+            let wb = getFilledTestWb()
+            let s = wb.ToRowsJsonString(noNumbering = true)
+            let wb2 = FsWorkbook.fromRowsJsonString(s)
+            Expect.workSheetEqual (wb2.GetWorksheetAt(1)) (wb.GetWorksheetAt(1)) "NoNumber Filled Write-Read"
+
+        testCase "NoNumber DefaultTestObject Write-Read_Success" <| fun _ -> 
+            let dto = DefaultTestObject.defaultTestObject()
+            let s = dto.ToRowsJsonString(noNumbering = true)
+            let dto2 = FsWorkbook.fromRowsJsonString(s)
+            ()
+
+        testCase "DefaultTestObject Write-Read" <| fun _ ->
             let dto = DefaultTestObject.defaultTestObject()
             let s = dto.ToRowsJsonString()
             let dto2 = FsWorkbook.fromRowsJsonString(s)
@@ -63,7 +121,53 @@ let rows =
 let columns =
     testList "Columns" [
 
-        testCase "Read-Write DefaultTestObject" <| fun _ ->
+        testCase "NoNumber Filled Write" <| fun _ ->
+            let wb = getFilledTestWb()
+            let expectedString = """{
+  "sheets": [
+    {
+      "name": "MySheet",
+      "columns": [
+        {
+          "cells": [
+            {
+              "value": "A1"
+            },
+            {
+              "value": "A2"
+            }
+          ]
+        },
+        {
+          "cells": [
+            {
+              "value": "B1"
+            },
+            {
+              "value": "B2"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}"""
+            let s = wb.ToColumnsJsonString(noNumbering = true)
+            Expect.stringEqual s expectedString "NoNumber Filled Write-Read"
+            
+        testCase "NoNumber Filled Write-Read" <| fun _ ->
+            let wb = getFilledTestWb()
+            let s = wb.ToColumnsJsonString(noNumbering = true)
+            let wb2 = FsWorkbook.fromColumnsJsonString(s)
+            Expect.workSheetEqual (wb2.GetWorksheetAt(1)) (wb.GetWorksheetAt(1)) "NoNumber Filled Write-Read"
+
+        testCase "NoNumber DefaultTestObject Write-Read_Success" <| fun _ ->
+            let dto = DefaultTestObject.defaultTestObject()
+            let s = dto.ToColumnsJsonString(noNumbering = true)
+            let dto2 = FsWorkbook.fromColumnsJsonString(s)
+            ()
+
+        testCase "DefaultTestObject Write-Read" <| fun _ ->
             let dto = DefaultTestObject.defaultTestObject()
             let s = dto.ToColumnsJsonString()
             let dto2 = FsWorkbook.fromColumnsJsonString(s)

--- a/tests/TestUtils/TestingUtils.fs
+++ b/tests/TestUtils/TestingUtils.fs
@@ -161,7 +161,7 @@ module Expect =
     let workSheetEqual (actual : FsWorksheet) (expected : FsWorksheet) message =
         let f (ws : FsWorksheet) = 
             ws.RescanRows()
-            ws.Rows |> Seq.map (fun r -> r.Cells) 
+            ws.Rows |> Seq.map (fun r -> r.Cells |> Seq.filter (fun c -> c.Value <> ""))
         if actual.Name <> expected.Name then
             failwithf $"{message}. Worksheet names do not match. Expected {expected.Name} but got {actual.Name}"
         columnsEqual (f actual) (f expected) $"{message}. Worksheet does not match"

--- a/tests/TestUtils/TestingUtils.fs
+++ b/tests/TestUtils/TestingUtils.fs
@@ -6,6 +6,29 @@ open Fable.Core
 open Fable.Pyxpecto
 
 
+module Fable =
+    
+    module JS =
+
+        [<Emit("process.stdout.write($0)")>]
+        let print (s:string) : unit = nativeOnly
+
+    module Py =
+
+        [<Emit("print($0, end = \"\")")>]
+        let print (s:string) : unit = nativeOnly
+
+    let fprint(s: string) =
+        #if FABLE_COMPILER_JAVASCRIPT
+        JS.print(s)
+        #endif
+        #if FABLE_COMPILER_PYTHON
+        Py.print(s)
+        #endif
+        #if !FABLE_COMPILER
+        printf "%s" s
+        #endif
+
 [<RequireQualifiedAccess>]
 module Utils = 
 
@@ -44,6 +67,33 @@ type Stopwatch() =
 
 /// Fable compatible Expecto/Mocha unification
 module Expect =
+
+    let inline equal actual expected message = Expect.equal actual expected message
+    let notEqual actual expected message = Expect.notEqual actual expected message
+
+    /// <summary>
+    /// This function only verifies non-whitespace characters
+    /// </summary>
+    let stringEqual actual expected message =
+        let pattern = @"\s+"
+        let regex = System.Text.RegularExpressions.Regex(pattern, Text.RegularExpressions.RegexOptions.Singleline)
+        let actual = regex.Replace(actual, "")
+        let expected = regex.Replace(expected, "")
+        let mutable isSame = true
+        Seq.iter2 
+            (fun s1 s2 -> 
+                if isSame && s1 = s2 then 
+                    ()
+                elif isSame && s1 <> s2 then
+                    isSame <- false
+                    Fable.fprint (sprintf "%s" (string s1))
+                else
+                    Fable.fprint (sprintf "%s" (string s1))
+            ) 
+            actual 
+            expected
+        equal actual expected message
+
 
     /// Expects the `actual` sequence to equal the `expected` one.
     let inline private _sequenceEqual message (comparison: int * 'a option * 'a option) =
@@ -132,9 +182,6 @@ module Expect =
                 let actualRows = ws.Rows
                 for actualRow, expectedRow in Seq.zip actualRows expectedRows do
                     cellSequenceEquals actualRow expectedRow $"ExpectError: Worksheet rows are not equal for worksheet: {ws.Name}"
-
-    let inline equal actual expected message = Expect.equal actual expected message
-    let notEqual actual expected message = Expect.notEqual actual expected message
 
     let isNull actual message = Expect.isNull actual message 
     let isNotNull actual message = Expect.isNotNull actual message 


### PR DESCRIPTION
#95

Json writers now contain a `noNumbering` flag, which skips indexes when writing:

```fsharp
open FsSpreadsheet
open FsSpreadsheet.Net

let wb = new FsWorkbook()
let ws = FsWorkbook.initWorksheet "MySheet" wb
let r1 = ws.Row(1)
r1.[1].SetValueAs "A1"
r1.[2].SetValueAs "B1"
let r2 = ws.Row(2)
r2.[1].SetValueAs "A2"
r2.[2].SetValueAs "B2"

wb.ToRowsJsonString(noNumbering = true)
```
-> 
```json
{
  "sheets": [
    {
      "name": "MySheet",
      "rows": [
        {
          "cells": [
            {
              "value": "A1"
            },
            {
              "value": "B1"
            }
          ]
        },
        {
          "cells": [
            {
              "value": "A2"
            },
            {
              "value": "B2"
            }
          ]
        }
      ]
    }
  ]
}
```

