### PR TITLE
Small fixes

### DIFF
--- a/build/TestTasks.fs
+++ b/build/TestTasks.fs
@@ -50,7 +50,7 @@ module RunTests =
             ]
         for path in testProjectsPy do
             //transpile py files from fsharp code
-            run dotnet $"fable {path} -o {path}/py --lang python" ""
+            run dotnet $"fable {path} -o {path}/py --lang python --nocache" ""
             // run pyxpecto in target path to execute tests in python
             run python $"{path}/py/main.py" ""
     }

--- a/src/FsSpreadsheet.Js/Workbook.fs
+++ b/src/FsSpreadsheet.Js/Workbook.fs
@@ -14,6 +14,7 @@ module JsWorkbook =
     let private log (obj:obj) = jsNative
 
     let writeFromFsWorkbook (fswb: FsWorkbook) =
+        FsWorkbook.validateForWrite fswb
         let jswb = ExcelJs.Excel.Workbook()
         jswb?_themes <- Aux.theme1
         for fsws in fswb.GetWorksheets() do

--- a/src/FsSpreadsheet.Net/FsExtensions.fs
+++ b/src/FsSpreadsheet.Net/FsExtensions.fs
@@ -159,7 +159,11 @@ module FsExtensions =
             let topLeftBoundary, bottomRightBoundary = Table.getArea table |> Table.Area.toBoundaries
             let ra = FsRangeAddress(FsAddress.fromString(topLeftBoundary), FsAddress.fromString(bottomRightBoundary))
             let totalsRowShown = if table.TotalsRowShown = null then false else table.TotalsRowShown.Value
-            FsTable(table.DisplayName, ra, totalsRowShown, true)
+            let showHeaderRow = if table.HeaderRowCount.HasValue && table.HeaderRowCount.Value = 0u then false else true
+            let fieldNames = 
+                table.TableColumns
+                |> Seq.map (fun c -> (c :?> TableColumn).Id.InnerText)
+            FsTable(table.DisplayName, ra, showTotalsRow = totalsRowShown, showHeaderRow = showHeaderRow, fieldNames = fieldNames)
 
         /// <summary>
         /// Returns the FsWorksheet associated with the FsTable in a given FsWorkbook.

--- a/src/FsSpreadsheet.Net/FsExtensions.fs
+++ b/src/FsSpreadsheet.Net/FsExtensions.fs
@@ -159,11 +159,15 @@ module FsExtensions =
             let topLeftBoundary, bottomRightBoundary = Table.getArea table |> Table.Area.toBoundaries
             let ra = FsRangeAddress(FsAddress.fromString(topLeftBoundary), FsAddress.fromString(bottomRightBoundary))
             let totalsRowShown = if table.TotalsRowShown = null then false else table.TotalsRowShown.Value
-            let showHeaderRow = if table.HeaderRowCount.HasValue && table.HeaderRowCount.Value = 0u then false else true
+            let showHeaderRow = if table.HeaderRowCount <> null && table.HeaderRowCount.HasValue && table.HeaderRowCount.Value = 0u then false else true
             let fieldNames = 
-                table.TableColumns
-                |> Seq.map (fun c -> (c :?> TableColumn).Id.InnerText)
-            FsTable(table.DisplayName, ra, showTotalsRow = totalsRowShown, showHeaderRow = showHeaderRow, fieldNames = fieldNames)
+                if table.TableColumns |> Seq.length = 0 then
+                    None
+                else
+                    table.TableColumns
+                    |> Seq.map (fun c -> (c :?> TableColumn).Id.InnerText)
+                    |> Some 
+            FsTable(table.DisplayName, ra, showTotalsRow = totalsRowShown, showHeaderRow = showHeaderRow, ?fieldNames = fieldNames)
 
         /// <summary>
         /// Returns the FsWorksheet associated with the FsTable in a given FsWorkbook.
@@ -382,6 +386,8 @@ module FsExtensions =
 
         member self.ToEmptySpreadsheet(doc : Packaging.SpreadsheetDocument) =
             
+            FsWorkbook.validateForWrite self
+
             let workbookPart = Spreadsheet.initWorkbookPart doc
 
             for worksheet in self.GetWorksheets() do

--- a/src/FsSpreadsheet.Net/Table.fs
+++ b/src/FsSpreadsheet.Net/Table.fs
@@ -25,8 +25,11 @@ module Table =
 
         /// Given a "A1:A1"-style area, returns A1-based cell start and end cellReferences.
         let toBoundaries (area : StringValue) = 
-            area.Value.Split ':'
-            |> fun a -> a.[0], a.[1]
+            if area.Value.Contains ":" then
+                area.Value.Split ':'
+                |> fun a -> a.[0], a.[1]
+            else 
+                area.Value, area.Value
 
         /// Gets the right boundary of the area.
         let rightBoundary (area : StringValue) = 

--- a/src/FsSpreadsheet.Py/Workbook.fs
+++ b/src/FsSpreadsheet.Py/Workbook.fs
@@ -8,6 +8,7 @@ module PyWorkbook =
     open Fable.Core.PyInterop
 
     let fromFsWorkbook (fsWB: FsWorkbook) : Workbook =
+        FsWorkbook.validateForWrite fsWB
         if fsWB.GetWorksheets().Count = 0 then 
            failwith "Workbook must contain at least one worksheet"
         let pyWB = Workbook.create()

--- a/src/FsSpreadsheet/Cells/FsCell.fs
+++ b/src/FsSpreadsheet/Cells/FsCell.fs
@@ -71,8 +71,8 @@ type FsCell (value : obj, ?dataType : DataType, ?address : FsAddress) =
     let mutable _formulaA1 = ""
     let mutable _formulaR1C1 = ""
 
-    let mutable _rowIndex : int = address |> Option.map (fun a -> a.RowNumber) |> Option.defaultValue 0
-    let mutable _columnIndex : int = address |> Option.map (fun a -> a.ColumnNumber) |> Option.defaultValue 0
+    let mutable _rowIndex : int = address |> Option.map (fun a -> a.RowNumber) |> Option.defaultValue 1
+    let mutable _columnIndex : int = address |> Option.map (fun a -> a.ColumnNumber) |> Option.defaultValue 1
 
     //new(value: IConvertible, ?dataType : DataType, ?address : FsAddress) = FsCell(box value, ?dataType = dataType, ?address = address)
     /// Creates an empty FsCell, set at row 0, column 0 (1-based).

--- a/src/FsSpreadsheet/FsWorkbook.fs
+++ b/src/FsSpreadsheet/FsWorkbook.fs
@@ -181,3 +181,11 @@ type FsWorkbook() =
     /// </summary>
     static member getTables (workbook : FsWorkbook) =
         workbook.GetTables()
+
+
+    static member validateForWrite (workbook : FsWorkbook) =
+        try 
+            workbook.GetWorksheets()
+            |> Seq.iter (fun ws -> FsWorksheet.validateForWrite ws)
+        with 
+        | ex -> failwith $"FsWorkbook could not be validated for write: {ex.Message}"

--- a/src/FsSpreadsheet/FsWorksheet.fs
+++ b/src/FsSpreadsheet/FsWorksheet.fs
@@ -636,7 +636,15 @@ type FsWorksheet (name, ?fsRows, ?fsTables, ?fsCellsCollection) =
     static member addCells (cell:seq<FsCell>) (sheet :FsWorksheet) =
         sheet.AddCells cell 
         
-
+    /// <summary>
+    /// Validate the FsWorksheet for writign to xlsx file.
+    /// </summary>
+    static member validateForWrite (ws : FsWorksheet) =
+        try
+            ws.Tables
+            |> Seq.iter (fun t -> FsTable.validateForWrite t ws.CellCollection)
+        with
+        | ex -> failwithf "FsWorksheet %s could not be validated for writing to xlsx file. %s" ws.Name ex.Message
 
     // TO DO (later)
     //static member tryRemoveValueAt 

--- a/src/FsSpreadsheet/Tables/FsTable.fs
+++ b/src/FsSpreadsheet/Tables/FsTable.fs
@@ -482,6 +482,13 @@ type FsTable (name : string, rangeAddress : FsRangeAddress, ?showTotalsRow : boo
     static member copy (table : FsTable) =
         table.Copy()
 
+    /// <summary>
+    /// Validates that the FsTable contains at least one body row.
+    /// </summary>
+    static member validateForWrite (table : FsTable) (cellsCollection : FsCellsCollection) =
+        if table.GetBodyRows(cellsCollection) |> Seq.length = 0 then
+            raise (System.ArgumentException(sprintf "The table '%s' must contain at least one body row." table.Name, "table"))
+
 
     /// Updates the TableFields according to the range of the table and the underlying cellcollection.
     ///

--- a/src/FsSpreadsheet/Tables/FsTable.fs
+++ b/src/FsSpreadsheet/Tables/FsTable.fs
@@ -94,7 +94,7 @@ type FsTable (name : string, rangeAddress : FsRangeAddress, ?showTotalsRow : boo
         }
 
     /// <summary>
-    /// Returns the FsRows from the FsTable.
+    /// Returns the FsRows from the FsTable, including HeaderRows if present. If only the body rows are needed, use GetBodyRows.
     /// </summary>
     /// <param name="cellsCollection">The FsCellsCollection associated with this FsTable.</param>
     member this.GetRows(cellsCollection : FsCellsCollection) =
@@ -105,6 +105,43 @@ type FsTable (name : string, rangeAddress : FsRangeAddress, ?showTotalsRow : boo
                 let range = FsRangeAddress (firstAddress, lastAddress)
                 FsRow(range, cellsCollection)
         }
+
+    /// <summary>
+    /// Returns the body rows from the FsTable, i.e. all rows except the header row (if shown).
+    /// </summary>
+    /// <param name="cellsCollection">The FsCellsCollection associated with this FsTable.</param>
+    member this.GetBodyRows(cellsCollection : FsCellsCollection) =
+        let firstRowIndex = if this.ShowHeaderRow then this.RangeAddress.FirstAddress.RowNumber + 1 else this.RangeAddress.FirstAddress.RowNumber
+        seq {
+            for i = firstRowIndex to this.RangeAddress.LastAddress.RowNumber do 
+                let firstAddress = FsAddress(i, this.RangeAddress.FirstAddress.ColumnNumber)
+                let lastAddress = FsAddress(i, this.RangeAddress.LastAddress.ColumnNumber)
+                let range = FsRangeAddress (firstAddress, lastAddress)
+                FsRow(range, cellsCollection)
+        }
+
+    /// <summary>
+    /// Returns the FsRow at the given index from the FsTable.
+    /// </summary>
+    /// <param name="index">The index of the row in the FsTable, starting with 1.</param>
+    member this.GetRowAt(index : int32, cellsCollection : FsCellsCollection) =
+        if (index <= 0 || index > base.RowCount()) then
+            raise (new System.ArgumentOutOfRangeException(string index,sprintf "Row index must be between 1 and %i" (base.RowCount())))
+        let rowI = this.RangeAddress.FirstAddress.RowNumber + index - 1
+        let firstAddress = FsAddress(rowI, this.RangeAddress.FirstAddress.ColumnNumber)
+        let lastAddress = FsAddress(rowI, this.RangeAddress.LastAddress.ColumnNumber)
+        let range = FsRangeAddress (firstAddress, lastAddress)
+        FsRow(range, cellsCollection)
+
+    /// <summary>
+    /// Returns the body FsRow at the given index from the FsTable, i.e. all rows except the header row (if shown).
+    /// </summary>
+    /// <param name="index">The index of the body row in the FsTable, starting with 1.</param>
+    member this.GetBodyRowAt(index : int32, cellsCollection : FsCellsCollection) =
+        if this.ShowHeaderRow then 
+            this.GetRowAt(index + 1, cellsCollection)
+        else
+            this.GetRowAt(index, cellsCollection)
 
     /// <summary>
     /// Updates the FsRangeAddress of the FsTable according to the FsTableFields associated.

--- a/tests/FsSpreadsheet.Net.Tests/FsWorkbook.fs
+++ b/tests/FsSpreadsheet.Net.Tests/FsWorkbook.fs
@@ -64,6 +64,23 @@ let writeAndReadBytes =
             Expect.workSheetEqual (wb.GetWorksheetByName(TestObjects.sheet1Name)) (wb2.GetWorksheetByName(TestObjects.sheet1Name)) "First Worksheet did not match"
             Expect.workSheetEqual (wb.GetWorksheetByName(TestObjects.sheet2Name)) (wb2.GetWorksheetByName(TestObjects.sheet2Name)) "Second Worksheet did not match"
         )
+        testCase "worksOnFilledTable (issue #100)" <| fun _ ->
+            let fsWB = new FsWorkbook()
+            let ws = fsWB.InitWorksheet("my awesome worksheet")
+            ws.AddCell(FsCell.createWithAdress(FsAddress.fromString("b1")) "my column 1") |> ignore
+            ws.AddCell(FsCell.createWithAdress(FsAddress.fromString("c1")) "my column 2") |> ignore
+            ws.AddCell(FsCell.createWithAdress(FsAddress.fromString("b2")) 2) |> ignore
+            ws.AddCell(FsCell.createWithAdress(FsAddress.fromString("c2")) "row2") |> ignore
+            ws.AddTable(FsTable("my_new_table", FsRangeAddress.fromString("b1:c2"))) |> ignore
+            fsWB.ToXlsxBytes() |> ignore
+
+        testCase "failsOnEmptyTable (issue #100)" <| fun _ ->
+            let fsWB = new FsWorkbook()
+            let ws = fsWB.InitWorksheet("my awesome worksheet")
+            ws.AddCell(FsCell.createWithAdress(FsAddress.fromString("b1")) "my column 1") |> ignore
+            ws.AddCell(FsCell.createWithAdress(FsAddress.fromString("c1")) "my column 2") |> ignore
+            ws.AddTable(FsTable("my_new_table", FsRangeAddress.fromString("b1:c1"))) |> ignore
+            Expect.throws (fun () -> fsWB.ToXlsxBytes() |> ignore) "no body in table"
     ]
 
 let performance =

--- a/tests/FsSpreadsheet.Py.Tests/Workbook.Tests.fs
+++ b/tests/FsSpreadsheet.Py.Tests/Workbook.Tests.fs
@@ -132,6 +132,23 @@ let tests_toPyWorkbook = testList "toPyWorkbook" [
         Expect.passWithMsg "convert to jswb"
         let pyWsList = pyWB?worksheets
         Expect.equal (pyWsList |> Array.length) 1 "worksheet count"
+    testCase "worksOnFilledTable (issue #100)" <| fun _ ->
+        let fsWB = new FsWorkbook()
+        let ws = fsWB.InitWorksheet("my awesome worksheet")
+        ws.AddCell(FsCell.createWithAdress(FsAddress.fromString("b1")) "my column 1") |> ignore
+        ws.AddCell(FsCell.createWithAdress(FsAddress.fromString("c1")) "my column 2") |> ignore
+        ws.AddCell(FsCell.createWithAdress(FsAddress.fromString("b2")) 2) |> ignore
+        ws.AddCell(FsCell.createWithAdress(FsAddress.fromString("c2")) "row2") |> ignore
+        ws.AddTable(FsTable("my_new_table", FsRangeAddress.fromString("b1:c2"))) |> ignore
+        PyWorkbook.fromFsWorkbook fsWB |> ignore
+    testCase "failsOnEmptyTable (issue #100)" <| fun _ ->
+        let fsWB = new FsWorkbook()
+        let ws = fsWB.InitWorksheet("my awesome worksheet")
+        ws.AddCell(FsCell.createWithAdress(FsAddress.fromString("b1")) "my column 1") |> ignore
+        ws.AddCell(FsCell.createWithAdress(FsAddress.fromString("c1")) "my column 2") |> ignore
+        ws.AddTable(FsTable("my_new_table", FsRangeAddress.fromString("b1:c1"))) |> ignore
+        Expect.throws (fun () -> PyWorkbook.fromFsWorkbook fsWB |> ignore) "no body in table"
+        
         //pyWB?worksheets
         //|> List.map (fun (ws : FsWorksheet) -> ws.Name = "my awesome worksheet")
 

--- a/tests/FsSpreadsheet.Tests/FsTableTests.fs
+++ b/tests/FsSpreadsheet.Tests/FsTableTests.fs
@@ -3,30 +3,42 @@
 open Fable.Pyxpecto
 open FsSpreadsheet
 
+let dummyRow1 = 
+    [   // single cells in row
+        FsCell.createWithDataType DataType.String 2 2 "Name"
+        FsCell.createWithDataType DataType.String 2 3 "Age"
+        FsCell.createWithDataType DataType.String 2 4 "Location"
+    ]
+let dummyRow2 = 
+    [   // single cells in row
+        FsCell.createWithDataType DataType.String 3 2 "John Doe"
+        FsCell.createWithDataType DataType.Number 3 3 "69"
+        FsCell.createWithDataType DataType.String 3 4 "Springfield"
+    ]
+
+let dummyRow3 = 
+    [   // single cells in row
+        FsCell.createWithDataType DataType.String 4 2 "Jane Doe"
+        FsCell.createWithDataType DataType.Number 4 3 "23"
+        FsCell.createWithDataType DataType.String 4 4 "Springfield"
+    ]
+
+let dummyRow4 = 
+    [   // single cells in row
+        FsCell.createWithDataType DataType.String 5 2 "Jack Doe"
+        FsCell.createWithDataType DataType.Number 5 3 "4"
+        FsCell.createWithDataType DataType.String 5 4 "Newville"
+    ]
+
 let dummyFsCells = 
     [   // rows
-        [   // single cells in row
-            FsCell.createWithDataType DataType.String 2 2 "Name"
-            FsCell.createWithDataType DataType.String 2 3 "Age"
-            FsCell.createWithDataType DataType.String 2 4 "Location"
-        ]
-        [
-            FsCell.createWithDataType DataType.String 3 2 "John Doe"
-            FsCell.createWithDataType DataType.Number 3 3 "69"
-            FsCell.createWithDataType DataType.String 3 4 "Springfield"
-        ]
-        [
-            FsCell.createWithDataType DataType.String 4 2 "Jane Doe"
-            FsCell.createWithDataType DataType.Number 4 3 "23"
-            FsCell.createWithDataType DataType.String 4 4 "Springfield"
-        ]
-        [
-            FsCell.createWithDataType DataType.String 5 2 "Jack Doe"
-            FsCell.createWithDataType DataType.Number 5 3 "4"
-            FsCell.createWithDataType DataType.String 5 4 "Newville"
-        ]
+        dummyRow1
+        dummyRow2
+        dummyRow3
+        dummyRow4
     ]
     |> Seq.concat
+
 let dummyFsRangeColumns =
     dummyFsCells
     |> Seq.groupBy (fun t -> t.ColumnNumber)
@@ -160,5 +172,66 @@ let main =
                     let actualCells = dummyFsCells |> Seq.filter (fun c -> c.ColumnNumber = 2 && c.RowNumber > minRowNo)
                     Expect.mySequenceEqual (testDataCells |> Seq.map (fun c -> c.Value)) (actualCells |> Seq.map (fun c -> c.Value)) "FsCells are incorrect in value"
             ]
+        ]
+        testList "GetRows" [
+            testCase "Headerless" <| fun _ ->
+                let t = FsTable("testFsTable", FsRangeAddress(dummyFsCellsCollectionFirstAddress, dummyFsCellsCollectionLastAddress), showHeaderRow = false)
+                let rows = t.GetRows(dummyFsCellsCollection) |> Seq.toArray
+                Expect.hasLength rows 4 "There should be 4 rows"
+                Expect.mySequenceEqual rows[0] dummyRow1 "Row 1 is not equal"
+                Expect.mySequenceEqual rows[1] dummyRow2 "Row 2 is not equal"
+                Expect.mySequenceEqual rows[2] dummyRow3 "Row 3 is not equal"
+                Expect.mySequenceEqual rows[3] dummyRow4 "Row 4 is not equal"      
+            testCase "HeadersShown" <| fun _ ->
+                let t = FsTable("testFsTable", FsRangeAddress(dummyFsCellsCollectionFirstAddress, dummyFsCellsCollectionLastAddress), showHeaderRow = true)
+                let rows = t.GetRows(dummyFsCellsCollection) |> Seq.toArray
+                Expect.hasLength rows 4 "There should be 4 rows"
+                Expect.mySequenceEqual rows[0] dummyRow1 "Row 1 is not equal"
+                Expect.mySequenceEqual rows[1] dummyRow2 "Row 2 is not equal"
+                Expect.mySequenceEqual rows[2] dummyRow3 "Row 3 is not equal"
+                Expect.mySequenceEqual rows[3] dummyRow4 "Row 4 is not equal"     
+        ]
+        testList "GetHeaderRow" [
+            testCase "HeadersShown" <| fun _ ->
+                let t = FsTable("testFsTable", FsRangeAddress(dummyFsCellsCollectionFirstAddress, dummyFsCellsCollectionLastAddress), showHeaderRow = true)
+                let headerRow = t.GetHeaderRow(dummyFsCellsCollection) 
+                Expect.mySequenceEqual headerRow dummyRow1 "Header row is not equal"              
+        ]
+        testList "GetBodyRows" [
+            testCase "HeadersShown" <| fun _ ->
+                let t = FsTable("testFsTable", FsRangeAddress(dummyFsCellsCollectionFirstAddress, dummyFsCellsCollectionLastAddress), showHeaderRow = true)
+                let bodyRows = t.GetBodyRows(dummyFsCellsCollection) |> Seq.toArray
+                Expect.hasLength bodyRows 3 "There should be 3 body rows"
+                Expect.mySequenceEqual bodyRows[0] dummyRow2 "Body Row 1 is not equal"
+                Expect.mySequenceEqual bodyRows[1] dummyRow3 "Body Row 2 is not equal"
+                Expect.mySequenceEqual bodyRows[2] dummyRow4 "Body Row 3 is not equal"       
+            testCase "Headerless" <| fun _ ->
+                let t = FsTable("testFsTable", FsRangeAddress(dummyFsCellsCollectionFirstAddress, dummyFsCellsCollectionLastAddress), showHeaderRow = false)
+                let bodyRows = t.GetBodyRows(dummyFsCellsCollection) |> Seq.toArray
+                Expect.hasLength bodyRows 4 "There should be 4 body rows"
+                Expect.mySequenceEqual bodyRows[0] dummyRow1 "Body Row 1 is not equal"
+                Expect.mySequenceEqual bodyRows[1] dummyRow2 "Body Row 2 is not equal"
+                Expect.mySequenceEqual bodyRows[2] dummyRow3 "Body Row 3 is not equal"       
+                Expect.mySequenceEqual bodyRows[3] dummyRow4 "Body Row 4 is not equal"
+        ]
+        testList "GetRowAt" [
+            testCase "HeadersShown" <| fun _ ->
+                let t = FsTable("testFsTable", FsRangeAddress(dummyFsCellsCollectionFirstAddress, dummyFsCellsCollectionLastAddress), showHeaderRow = true)
+                let row2 = t.GetRowAt(2, dummyFsCellsCollection) 
+                Expect.mySequenceEqual row2 dummyRow2 "Row 2 is not equal"
+            testCase "Headerless" <| fun _ ->
+                let t = FsTable("testFsTable", FsRangeAddress(dummyFsCellsCollectionFirstAddress, dummyFsCellsCollectionLastAddress), showHeaderRow = false)
+                let row2 = t.GetRowAt(2, dummyFsCellsCollection) 
+                Expect.mySequenceEqual row2 dummyRow2 "Row 2 is not equal"
+        ]
+        testList "GetBodyRowAt" [
+            testCase "HeadersShown" <| fun _ ->
+                let t = FsTable("testFsTable", FsRangeAddress(dummyFsCellsCollectionFirstAddress, dummyFsCellsCollectionLastAddress), showHeaderRow = true)
+                let bodyRow1 = t.GetBodyRowAt(1, dummyFsCellsCollection) 
+                Expect.mySequenceEqual bodyRow1 dummyRow2 "Body Row 1 is not equal"
+            testCase "Headerless" <| fun _ ->
+                let t = FsTable("testFsTable", FsRangeAddress(dummyFsCellsCollectionFirstAddress, dummyFsCellsCollectionLastAddress), showHeaderRow = false)
+                let bodyRow1 = t.GetBodyRowAt(1, dummyFsCellsCollection) 
+                Expect.mySequenceEqual bodyRow1 dummyRow1 "Body Row 1 is not equal"
         ]
     ]


### PR DESCRIPTION
- closes #100
  [writing to xlsx files fails now if table object does not contain any body row](https://github.com/fslaborg/FsSpreadsheet/commit/0e2b0b572ddb63eec91e5a7c3fe2f5da20794350) 


- closes #39
  [cells are initialized at index 1 by default](https://github.com/fslaborg/FsSpreadsheet/commit/dc4b5256f35732cc75378db15c3bc93f61db18f5)
- closes #44
  [fix dotnet parser failing reading headerless tables](https://github.com/fslaborg/FsSpreadsheet/commit/c4200425e2a5f277b15cdbcf1d6eb5c84f51b19f)
- closes #45 
  [add some table row access functions and add tests](https://github.com/fslaborg/FsSpreadsheet/commit/3b576532ec315d8f69e1a5e1f53a0fab3fa8c2a4)